### PR TITLE
move stats-lite to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
     "newcap": false,
     "eqeqeq": false
   },
-  "dependencies": {},
+  "dependencies": {
+    "stats-lite": "^2.1.0"
+  },
   "devDependencies": {
     "standard": "~10.0.2",
-    "stats-lite": "^2.1.0",
     "tape": "~4.7.0"
   },
   "repository": {


### PR DESCRIPTION
When moving average were added in d88fe0aea7ef stats-lite became a
regular dependency because it is referenced unconditionally in the main
module code instead of only in the tests.

Unfortunately this broke some downstream packages :-(

Signed-off-by: Ryan Graham <r.m.graham@gmail.com>